### PR TITLE
Xinput Device Manager not attaching devices plugged in after setup

### DIFF
--- a/Assets/InControl/Library/XInput/XInputDeviceManager.cs
+++ b/Assets/InControl/Library/XInput/XInputDeviceManager.cs
@@ -24,7 +24,8 @@ namespace InControl
 
 
 		public override void Update( float updateTime, float deltaTime )
-		{
+        {
+            UpdateUnconnectedDevices(updateTime, deltaTime);
 			RefreshDevices();
 		}
 
@@ -50,6 +51,17 @@ namespace InControl
 				}
 			}
 		}
+
+        void UpdateUnconnectedDevices(float updateTime, float deltaTime)
+        {
+            for (int deviceIndex = 0; deviceIndex < 4; deviceIndex++)
+            {
+                var device = devices[deviceIndex] as XInputDevice;
+
+                if (!device.IsConnected)
+                    device.Update(updateTime, deltaTime);
+            }
+        }
 	}
 }
 


### PR DESCRIPTION
Unconnected xinput devices need to be Updated so their state can be query. Otherwise they will always remain 'unconnected'. 
