### PR TITLE
Joystick Names in Device Profiles can now be regular expressions

### DIFF
--- a/Assets/InControl/Library/Unity/DeviceProfiles/Xbox360MacProfile.cs
+++ b/Assets/InControl/Library/Unity/DeviceProfiles/Xbox360MacProfile.cs
@@ -21,6 +21,7 @@ namespace InControl
 			JoystickNames = new[]
 			{
 				"",
+				"/.+?x\\-?box 360.+?/",
 				"Microsoft Wireless 360 Controller",
 				"Mad Catz, Inc. Mad Catz FPS Pro GamePad",
 				"Logitech Gamepad F310"

--- a/Assets/InControl/Library/Unity/DeviceProfiles/Xbox360OuyaProfile.cs
+++ b/Assets/InControl/Library/Unity/DeviceProfiles/Xbox360OuyaProfile.cs
@@ -21,6 +21,7 @@ namespace InControl
 
 			JoystickNames = new[]
 			{
+				"/.+?x\\-?box 360.+?/",
 				"Microsoft X-Box 360 pad"
 			};
 

--- a/Assets/InControl/Library/Unity/DeviceProfiles/Xbox360WinProfile.cs
+++ b/Assets/InControl/Library/Unity/DeviceProfiles/Xbox360WinProfile.cs
@@ -20,6 +20,7 @@ namespace InControl
 
 			JoystickNames = new[]
 			{
+				"/.+?x\\-?box 360.+?/",
 				"Controller (XBOX 360 For Windows)",
 				"Controller (XBOX 360 Wireless Receiver for Windows)",
 				"XBOX 360 For Windows (Controller)",

--- a/Assets/InControl/Library/Unity/UnityInputDeviceProfile.cs
+++ b/Assets/InControl/Library/Unity/UnityInputDeviceProfile.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 
@@ -103,7 +104,24 @@ namespace InControl
 				return false;
 			}
 
-			return JoystickNames.Contains( joystickName, StringComparer.OrdinalIgnoreCase );
+			foreach(string joystick in JoystickNames)
+			{
+				if(joystick.First() == '/' && joystick.Last() == '/')
+				{
+					string joystickRegex = joystick.Split('/')[0];
+					
+					if(Regex.IsMatch(joystickName, joystickRegex, RegexOptions.IgnoreCase))
+					{
+						return true;
+					}
+				}
+				else if(joystick == joystickName)
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 


### PR DESCRIPTION
Joystick Names in Device Profiles can now be regular expressions: Put "/" at the beginning and end of a name.

I updated the Xbox 360 profiles to use regular expressions. I've tested on Windows with my GameStop and Rock Candy controllers.
