### PR TITLE
Circular Dead Zones working

### DIFF
--- a/Assets/InControl/Library/Control/InputControlMapping.cs
+++ b/Assets/InControl/Library/Control/InputControlMapping.cs
@@ -90,5 +90,34 @@ namespace InControl
 					   Target == InputControlType.RightStickY;
 			}
 		}
+
+        public bool IsStick
+        {
+            get
+            {
+                return Opposite.HasValue;
+            }
+        }
+
+        // for 2d circular deadzone check
+        public InputControlType? Opposite
+        {
+            get
+            {
+                switch (Target)
+                {
+                    case InputControlType.LeftStickX:
+                        return InputControlType.LeftStickY;
+                    case InputControlType.LeftStickY:
+                        return InputControlType.LeftStickX;
+                    case InputControlType.RightStickX:
+                        return InputControlType.RightStickY;
+                    case InputControlType.RightStickY:
+                        return InputControlType.RightStickX;
+                    default: // TODO: incomplete?
+                        return null;
+                }
+            }
+        }
 	}
 }

--- a/Assets/InControl/Library/XInput/XInputDevice.cs
+++ b/Assets/InControl/Library/XInput/XInputDevice.cs
@@ -82,8 +82,8 @@ namespace InControl
 
 
 		void QueryState()
-		{
-			state = GamePad.GetState( (PlayerIndex) DeviceIndex );
+        {
+            state = GamePad.GetState((PlayerIndex)DeviceIndex, GamePadDeadZone.Circular);
 		}
 
 


### PR DESCRIPTION
Implemented code that checks for circular dead zones (even if XInput is not used). Also changed the XInput/XInputDevice.cs to check for circular dead zones by default, using pbhogan's suggestion.

See issue: https://github.com/pbhogan/InControl/issues/63

Works like a charm on my pc, with my XBOX 360 controllers, using either XInput or not. Based test on vector output length [0,1] and the fact that no snapping is noticed at all. (In my game the cross hair now makes a perfect circle around the player)
