### PR TITLE
Moved JoystickId from UnityInputDevice to InputDevice

### DIFF
--- a/Assets/InControl/Library/Device/InputDevice.cs
+++ b/Assets/InControl/Library/Device/InputDevice.cs
@@ -12,6 +12,7 @@ namespace InControl
 
 		public string Name { get; protected set; }
 		public string Meta { get; protected set; }
+		public int JoystickId { get; protected set; }
 
 		public ulong LastChangeTick { get; protected set; }
 

--- a/Assets/InControl/Library/Unity/UnityInputDevice.cs
+++ b/Assets/InControl/Library/Unity/UnityInputDevice.cs
@@ -12,7 +12,6 @@ namespace InControl
 		public const int MaxButtons = 20;
 		public const int MaxAnalogs = 20;
 
-		public int JoystickId { get; private set; }
 		public UnityInputDeviceProfile Profile { get; protected set; }
 
 


### PR DESCRIPTION
Moved the JoystickId property from UnityInputDevice to InputDevice. I did this so that when doing things like the code below, I can use the JoystickId. This just seems to make it easy to track input devices especially when attached and detached as it gives them a somewhat unique identifier to use. This could be helpful if I want a player to always be using a specific input device and if it disconnected and reconnects, I can easily handle this.

``` csharp
foreach (InputDevice inputDevice in InputManager.Devices) {
    Debug.Log("Checking input with id: " + inputDevice.JoystickId);
}
```
