### PR TITLE
Added aditional GameStick Controller names

### DIFF
--- a/Assets/InControl/Library/Unity/DeviceProfiles/GameStickProfile.cs
+++ b/Assets/InControl/Library/Unity/DeviceProfiles/GameStickProfile.cs
@@ -20,7 +20,10 @@ namespace InControl
 
 			JoystickNames = new[]
 			{
-				"GameStick Controller 1"
+				"GameStick Controller 1",
+				"GameStick Controller 2",
+				"GameStick Controller 3",
+				"GameStick Controller 4"
 			};
 
 			Sensitivity = 1.0f;


### PR DESCRIPTION
Gamestick happens the controller number after the name, so the second controller is named "GameStick Controller 2", the third one "GameStick Controller 3", etc.
