### PR TITLE
initial import of support for ouya-everywhere api

### DIFF
--- a/Assets/InControl/Editor/InControlManagerEditor.cs
+++ b/Assets/InControl/Editor/InControlManagerEditor.cs
@@ -13,6 +13,7 @@ namespace InControl
 		SerializedProperty logDebugInfo;
 		SerializedProperty invertYAxis;
 		SerializedProperty enableXInput;
+		SerializedProperty enableOuyaEverywhereInput;
 		SerializedProperty useFixedUpdate;
 		SerializedProperty dontDestroyOnLoad;
 		SerializedProperty customProfiles;
@@ -24,6 +25,7 @@ namespace InControl
 			logDebugInfo = serializedObject.FindProperty( "logDebugInfo" );
 			invertYAxis = serializedObject.FindProperty( "invertYAxis" );
 			enableXInput = serializedObject.FindProperty( "enableXInput" );
+			enableOuyaEverywhereInput = serializedObject.FindProperty( "enableOuyaEverywhereInput" );
 			useFixedUpdate = serializedObject.FindProperty( "useFixedUpdate" );
 			dontDestroyOnLoad = serializedObject.FindProperty( "dontDestroyOnLoad" );
 			customProfiles = serializedObject.FindProperty( "customProfiles" );
@@ -48,6 +50,7 @@ namespace InControl
 			logDebugInfo.boolValue = EditorGUILayout.ToggleLeft( "Log Debug Info", logDebugInfo.boolValue );
 			invertYAxis.boolValue = EditorGUILayout.ToggleLeft( "Invert Y Axis", invertYAxis.boolValue );
 			enableXInput.boolValue = EditorGUILayout.ToggleLeft( "Enable XInput (Windows)", enableXInput.boolValue );
+			enableOuyaEverywhereInput.boolValue = EditorGUILayout.ToggleLeft( "Enable OuyaEverywhereInput (OUYA)", enableOuyaEverywhereInput.boolValue );
 			useFixedUpdate.boolValue = EditorGUILayout.ToggleLeft( "Use Fixed Update", useFixedUpdate.boolValue );
 			dontDestroyOnLoad.boolValue = EditorGUILayout.ToggleLeft( "Don't Destroy On Load", dontDestroyOnLoad.boolValue );
 

--- a/Assets/InControl/Library/InputManager.cs
+++ b/Assets/InControl/Library/InputManager.cs
@@ -30,6 +30,7 @@ namespace InControl
 		public static bool InvertYAxis;
 
 		static bool enableXInput;
+		static bool enableOuyaEverywhereInput;
 		static bool isSetup;
 
 		static float initialTime;
@@ -63,6 +64,12 @@ namespace InControl
 			if (enableXInput)
 			{
 				XInputDeviceManager.Enable();
+			}
+			#endif
+
+			#if UNITY_ANDROID && !UNITY_EDITOR
+			if (enableOuyaEverywhereInput) {
+				OuyaEverywhereDeviceManager.Enable();
 			}
 			#endif
 
@@ -318,6 +325,18 @@ namespace InControl
 			set
 			{
 				enableXInput = value;
+			}
+		}
+
+		public static bool EnableOuyaEverywhereInput
+		{
+			get
+			{
+				return enableOuyaEverywhereInput;
+			}
+			set
+			{
+				enableOuyaEverywhereInput = value;
 			}
 		}
 	}

--- a/Assets/InControl/Library/OuyaEverywhere.meta
+++ b/Assets/InControl/Library/OuyaEverywhere.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 6eeeaf1ea14374b9f88425dbd0d1886c
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDevice.cs
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDevice.cs
@@ -1,0 +1,100 @@
+#if UNITY_ANDROID && !UNITY_EDITOR
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using OuyaEverywhereHelpers;
+using tv.ouya.console.api;
+
+
+namespace InControl
+{
+	public class OuyaEverywhereDevice : InputDevice
+	{
+		public int DeviceIndex { get; private set; }
+		GamePadState state;
+
+
+		public OuyaEverywhereDevice( int deviceIndex )
+			: base( "Ouya Controller (OuyaEverywhere)" )
+		{
+			DeviceIndex = deviceIndex;
+			SortOrder   = deviceIndex;
+
+			Meta = "Ouya Device #" + deviceIndex;
+
+			AddControl( InputControlType.LeftStickX, "LeftStickX" );
+			AddControl( InputControlType.LeftStickY, "LeftStickY" );
+			AddControl( InputControlType.RightStickX, "RightStickX" );
+			AddControl( InputControlType.RightStickY, "RightStickY" );
+
+			AddControl( InputControlType.LeftTrigger, "LeftTrigger" );
+			AddControl( InputControlType.RightTrigger, "RightTrigger" );
+
+			AddControl( InputControlType.DPadUp, "DPadUp" );
+			AddControl( InputControlType.DPadDown, "DPadDown" );
+			AddControl( InputControlType.DPadLeft, "DPadLeft" );
+			AddControl( InputControlType.DPadRight, "DPadRight" );
+
+			AddControl( InputControlType.Action1, "Action1" );
+			AddControl( InputControlType.Action2, "Action2" );
+			AddControl( InputControlType.Action3, "Action3" );
+			AddControl( InputControlType.Action4, "Action4" );
+
+			AddControl( InputControlType.LeftBumper, "LeftBumper" );
+			AddControl( InputControlType.RightBumper, "RightBumper" );
+
+			AddControl( InputControlType.LeftStickButton, "LeftStickButton" );
+			AddControl( InputControlType.RightStickButton, "RightStickButton" );
+
+			AddControl( InputControlType.Start, "Start" );
+
+			QueryState();
+		}
+
+
+		public override void Update( ulong updateTick, float deltaTime )
+		{
+			QueryState();
+
+			UpdateWithValue( InputControlType.LeftStickX, state.ThumbSticks.Left.X, updateTick );
+			UpdateWithValue( InputControlType.LeftStickY, state.ThumbSticks.Left.Y, updateTick );
+			UpdateWithValue( InputControlType.RightStickX, state.ThumbSticks.Right.X, updateTick );
+			UpdateWithValue( InputControlType.RightStickY, state.ThumbSticks.Right.Y, updateTick );
+
+			UpdateWithValue( InputControlType.LeftTrigger, state.Triggers.Left, updateTick );
+			UpdateWithValue( InputControlType.RightTrigger, state.Triggers.Right, updateTick );
+
+			UpdateWithState( InputControlType.DPadUp, state.DPad.Up == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.DPadDown, state.DPad.Down == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.DPadLeft, state.DPad.Left == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.DPadRight, state.DPad.Right == ButtonState.Pressed, updateTick );
+
+			UpdateWithState( InputControlType.Action1, state.Buttons.O == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.Action2, state.Buttons.A == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.Action3, state.Buttons.U == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.Action4, state.Buttons.Y == ButtonState.Pressed, updateTick );
+
+			UpdateWithState( InputControlType.LeftBumper, state.Buttons.LeftShoulder == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.RightBumper, state.Buttons.RightShoulder == ButtonState.Pressed, updateTick );
+
+			UpdateWithState( InputControlType.LeftStickButton, state.Buttons.LeftStick == ButtonState.Pressed, updateTick );
+			UpdateWithState( InputControlType.RightStickButton, state.Buttons.RightStick == ButtonState.Pressed, updateTick );
+
+			UpdateWithState( InputControlType.Start, state.Buttons.Start == ButtonState.Pressed, updateTick );
+		}
+
+
+		void QueryState()
+		{
+			state = GamePad.GetState( (PlayerIndex) DeviceIndex );
+		}
+
+
+		public bool IsConnected
+		{
+			get { return state.IsConnected; }
+		}
+	}
+}
+#endif

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDevice.cs.meta
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDevice.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70b696ac91d6f42b1a14ab77b811603a
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDeviceManager.cs
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDeviceManager.cs
@@ -1,0 +1,82 @@
+#if UNITY_ANDROID && !UNITY_EDITOR
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using OuyaEverywhereHelpers;
+
+
+namespace InControl
+{
+	public class OuyaEverywhereDeviceManager : InputDeviceManager
+	{
+		bool[] deviceConnected = new bool[] { false, false, false, false };
+
+
+		public OuyaEverywhereDeviceManager()
+		{
+			for (int deviceIndex = 0; deviceIndex < 4; deviceIndex++)
+			{
+				devices.Add( new OuyaEverywhereDevice( deviceIndex ) );
+			}
+
+			Update( 0, 0.0f );
+		}
+
+
+		public override void Update( ulong updateTick, float deltaTime )
+		{
+			for (int deviceIndex = 0; deviceIndex < 4; deviceIndex++)
+			{
+				var device = devices[deviceIndex] as OuyaEverywhereDevice;
+
+				// Unconnected devices won't be updated otherwise, so poll here.
+				if (!device.IsConnected)
+				{
+					device.Update( updateTick, deltaTime );
+				}
+
+				if (device.IsConnected != deviceConnected[deviceIndex])
+				{
+					if (device.IsConnected)
+					{
+						InputManager.AttachDevice( device );
+					}
+					else
+					{
+						InputManager.DetachDevice( device );
+					}
+
+					deviceConnected[deviceIndex] = device.IsConnected;
+				}
+			}
+		}
+
+
+		public static bool CheckPlatformSupport( ICollection<string> errors )
+		{
+			// TODO: evaluate the need for this function
+			return true;
+		}
+
+
+		public static void Enable()
+		{
+			var errors = new List<string>();
+			if (OuyaEverywhereDeviceManager.CheckPlatformSupport( errors ))
+			{
+				InputManager.HideDevicesWithProfile( typeof( OuyaProfile ) );
+				InputManager.AddDeviceManager( new OuyaEverywhereDeviceManager() );
+			}
+			else
+			{
+				foreach (var error in errors)
+				{
+					Logger.LogError( error );
+				}
+			}
+		}
+	}
+}
+#endif
+

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDeviceManager.cs.meta
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereDeviceManager.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6f87be42542b42a2b8cb1843c54e241
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers.meta
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: c9689ff8e737442fbb4f9df5cb82d0cb
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/GamePad.cs
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/GamePad.cs
@@ -1,0 +1,341 @@
+﻿#if UNITY_ANDROID && !UNITY_EDITOR
+using System;
+using System.Runtime.InteropServices;
+using tv.ouya.console.api;
+
+namespace OuyaEverywhereHelpers
+{
+
+	public enum ButtonState
+	{
+		Pressed,
+		Released
+	}
+
+
+	public struct GamePadButtons
+	{
+		// a-o
+		// b-a
+		// x-u
+		// y-y
+		ButtonState start, leftStick, rightStick, leftShoulder, rightShoulder, o, a, u, y;
+
+		internal GamePadButtons( ButtonState start,  ButtonState leftStick, ButtonState rightStick,
+								ButtonState leftShoulder, ButtonState rightShoulder, ButtonState o, ButtonState a,
+								ButtonState u, ButtonState y )
+		{
+			this.start = start;
+			this.leftStick = leftStick;
+			this.rightStick = rightStick;
+			this.leftShoulder = leftShoulder;
+			this.rightShoulder = rightShoulder;
+			this.o = o;
+			this.a = a;
+			this.u = u;
+			this.y = y;
+		}
+
+
+		public ButtonState Start
+		{
+			get { return start; }
+		}
+
+
+		public ButtonState LeftStick
+		{
+			get { return leftStick; }
+		}
+
+
+		public ButtonState RightStick
+		{
+			get { return rightStick; }
+		}
+
+
+		public ButtonState LeftShoulder
+		{
+			get { return leftShoulder; }
+		}
+
+
+		public ButtonState RightShoulder
+		{
+			get { return rightShoulder; }
+		}
+
+
+		public ButtonState O
+		{
+			get { return o; }
+		}
+
+
+		public ButtonState A
+		{
+			get { return a; }
+		}
+
+
+		public ButtonState U
+		{
+			get { return u; }
+		}
+
+
+		public ButtonState Y
+		{
+			get { return y; }
+		}
+	}
+
+
+	public struct GamePadDPad
+	{
+		ButtonState up, down, left, right;
+
+		internal GamePadDPad( ButtonState up, ButtonState down, ButtonState left, ButtonState right )
+		{
+			this.up = up;
+			this.down = down;
+			this.left = left;
+			this.right = right;
+		}
+
+
+		public ButtonState Up
+		{
+			get { return up; }
+		}
+
+
+		public ButtonState Down
+		{
+			get { return down; }
+		}
+
+
+		public ButtonState Left
+		{
+			get { return left; }
+		}
+
+
+		public ButtonState Right
+		{
+			get { return right; }
+		}
+	}
+
+
+	public struct GamePadThumbSticks
+	{
+		public struct StickValue
+		{
+			float x, y;
+
+			internal StickValue(float x, float y)
+			{
+				this.x = x;
+				this.y = y;
+			}
+
+			public float X
+			{
+				get { return x; }
+			}
+
+			public float Y
+			{
+				get { return y; }
+			}
+		}
+
+		StickValue left, right;
+
+
+		internal GamePadThumbSticks( StickValue left, StickValue right )
+		{
+			this.left = left;
+			this.right = right;
+		}
+
+
+		public StickValue Left
+		{
+			get { return left; }
+		}
+
+
+		public StickValue Right
+		{
+			get { return right; }
+		}
+	}
+
+
+	public struct GamePadTriggers
+	{
+		float left;
+		float right;
+
+
+		internal GamePadTriggers( float left, float right )
+		{
+			this.left = left;
+			this.right = right;
+		}
+
+
+		public float Left
+		{
+			get { return left; }
+		}
+
+
+		public float Right
+		{
+			get { return right; }
+		}
+	}
+
+
+	public struct GamePadState
+	{
+		bool isConnected;
+		GamePadButtons buttons;
+		GamePadDPad dPad;
+		GamePadThumbSticks thumbSticks;
+		GamePadTriggers triggers;
+
+		internal GamePadState( PlayerIndex playerIndex)
+		{
+			this.isConnected = OuyaSDK.OuyaInput.IsControllerConnected((int)playerIndex);;
+
+			if (!isConnected) {
+				buttons = new GamePadButtons(
+					ButtonState.Released, 
+					ButtonState.Released, 
+					ButtonState.Released, 
+					ButtonState.Released, 
+					ButtonState.Released, 
+					ButtonState.Released, 
+					ButtonState.Released, 
+					ButtonState.Released,
+					ButtonState.Released
+					);
+
+				dPad = new GamePadDPad(
+					ButtonState.Released,
+					ButtonState.Released,
+					ButtonState.Released,
+					ButtonState.Released
+					);
+
+				thumbSticks = new GamePadThumbSticks(new GamePadThumbSticks.StickValue(0,0), new GamePadThumbSticks.StickValue(0,0));
+				triggers = new GamePadTriggers(0,0);
+
+			}else{
+				buttons = new GamePadButtons(
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_MENU) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_L3) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_R3) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_L1) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_R1) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_O) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_A) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_U) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_Y) ? ButtonState.Pressed : ButtonState.Released
+					);
+				dPad = new GamePadDPad(
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_DPAD_UP) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_DPAD_DOWN) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_DPAD_LEFT) ? ButtonState.Pressed : ButtonState.Released,
+					OuyaSDK.OuyaInput.GetButton((int)playerIndex, OuyaController.BUTTON_DPAD_RIGHT) ? ButtonState.Pressed : ButtonState.Released
+					);
+				
+				thumbSticks = new GamePadThumbSticks(
+					new GamePadThumbSticks.StickValue(
+					OuyaSDK.OuyaInput.GetAxis((int)playerIndex, OuyaController.AXIS_LS_X),
+					OuyaSDK.OuyaInput.GetAxis((int)playerIndex, OuyaController.AXIS_LS_Y)
+					),
+					new GamePadThumbSticks.StickValue(
+					OuyaSDK.OuyaInput.GetAxis((int)playerIndex, OuyaController.AXIS_RS_X),
+					OuyaSDK.OuyaInput.GetAxis((int)playerIndex, OuyaController.AXIS_RS_Y)
+					)
+				);
+				triggers = new GamePadTriggers(
+					OuyaSDK.OuyaInput.GetAxis((int)playerIndex, OuyaController.AXIS_L2),
+					OuyaSDK.OuyaInput.GetAxis((int)playerIndex, OuyaController.AXIS_R2)
+					);
+			}
+		}
+
+
+		public bool IsConnected
+		{
+			get { return isConnected; }
+		}
+
+
+		public GamePadButtons Buttons
+		{
+			get { return buttons; }
+		}
+
+
+		public GamePadDPad DPad
+		{
+			get { return dPad; }
+		}
+
+
+		public GamePadTriggers Triggers
+		{
+			get { return triggers; }
+		}
+
+
+		public GamePadThumbSticks ThumbSticks
+		{
+			get { return thumbSticks; }
+		}
+	}
+
+
+	public enum PlayerIndex
+	{
+		One = 0,
+		Two,
+		Three,
+		Four
+	}
+
+/*
+	public enum GamePadDeadZone
+	{
+		Circular,
+		IndependentAxes,
+		None
+	}
+*/
+
+	public class GamePad
+	{
+		public static GamePadState GetState( PlayerIndex playerIndex )
+		{
+			return new GamePadState( playerIndex );
+		}
+
+		/*
+		public static GamePadState GetState( PlayerIndex playerIndex, GamePadDeadZone deadZone )
+		{
+			return new GamePadState(result == Utils.Success, state, deadZone);
+		}
+		*/
+	}
+}
+#endif
+

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/GamePad.cs.meta
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/GamePad.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa10bd8e8ad85495890d0e5b5c1f77d7
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/Utils.cs
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/Utils.cs
@@ -1,0 +1,101 @@
+﻿#if UNITY_ANDROID && !UNITY_EDITOR
+using System;
+
+
+namespace OuyaEverywhereHelpers
+{
+	static class Utils
+	{
+		public const uint Success = 0x000;
+		public const uint NotConnected = 0x000;
+
+		private const int LeftStickDeadZone = 7849;
+		private const int RightStickDeadZone = 8689;
+		private const int TriggerDeadZone = 30;
+
+		/*
+		public static float ApplyTriggerDeadZone( byte value, GamePadDeadZone deadZoneMode )
+		{
+			if (deadZoneMode == GamePadDeadZone.None)
+			{
+				return ApplyDeadZone( value, byte.MaxValue, 0.0f );
+			}
+			else
+			{
+				return ApplyDeadZone( value, byte.MaxValue, TriggerDeadZone );
+			}
+		}
+
+
+		public static GamePadThumbSticks.StickValue ApplyLeftStickDeadZone( short valueX, short valueY, GamePadDeadZone deadZoneMode )
+		{
+			return ApplyStickDeadZone( valueX, valueY, deadZoneMode, LeftStickDeadZone );
+		}
+
+
+		public static GamePadThumbSticks.StickValue ApplyRightStickDeadZone(short valueX, short valueY, GamePadDeadZone deadZoneMode)
+		{
+			return ApplyStickDeadZone( valueX, valueY, deadZoneMode, RightStickDeadZone );
+		}
+
+
+		private static GamePadThumbSticks.StickValue ApplyStickDeadZone( short valueX, short valueY, GamePadDeadZone deadZoneMode, int deadZoneSize )
+		{
+			if (deadZoneMode == GamePadDeadZone.Circular)
+			{
+				// Cast to long to avoid int overflow if valueX and valueY are both 32768, which would result in a negative number and Sqrt returns NaN
+				float distanceFromCenter = (float)Math.Sqrt((long)valueX * (long)valueX + (long)valueY * (long)valueY);
+				float coefficient = ApplyDeadZone(distanceFromCenter, short.MaxValue, deadZoneSize);
+				coefficient = coefficient > 0.0f ? coefficient / distanceFromCenter : 0.0f;
+				return new GamePadThumbSticks.StickValue(
+					Clamp(valueX * coefficient),
+					Clamp(valueY * coefficient)
+				);
+			}
+			else if (deadZoneMode == GamePadDeadZone.IndependentAxes)
+			{
+				return new GamePadThumbSticks.StickValue(
+					ApplyDeadZone(valueX, short.MaxValue, deadZoneSize),
+					ApplyDeadZone(valueY, short.MaxValue, deadZoneSize)
+				);
+			}
+			else
+			{
+				return new GamePadThumbSticks.StickValue(
+					ApplyDeadZone(valueX, short.MaxValue, 0.0f),
+					ApplyDeadZone(valueY, short.MaxValue, 0.0f)
+				);
+			}
+		}
+
+
+		private static float Clamp( float value )
+		{
+			return value < -1.0f ? -1.0f : (value > 1.0f ? 1.0f : value);
+		}
+
+
+		private static float ApplyDeadZone( float value, float maxValue, float deadZoneSize )
+		{
+			if (value < -deadZoneSize)
+			{
+				value += deadZoneSize;
+			}
+			else if (value > deadZoneSize)
+			{
+				value -= deadZoneSize;
+			}
+			else
+			{
+				return 0.0f;
+			}
+
+			value /= maxValue - deadZoneSize;
+
+			return Clamp(value);
+		}
+		*/
+	}
+}
+#endif
+

--- a/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/Utils.cs.meta
+++ b/Assets/InControl/Library/OuyaEverywhere/OuyaEverywhereHelpers/Utils.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8672b88230ea44794bcbde0fb847da4f
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 


### PR DESCRIPTION
Basic support for OuyaEverywhere is present here.
I haven't included a DeadZone configuration.
There's still a bit of cleanup to be done around "don't poll OuyaEverywhere for data until the OuyaSDK is fully loaded" requirement.
This new implementation (compared to the legacy ouya-unity-plugin method) appears to reduce the gamepad input event latency on OUYA systems by ~60ms.
