### PR TITLE
Please make currentTick public

### DIFF
--- a/Assets/InControl/Library/InputManager.cs
+++ b/Assets/InControl/Library/InputManager.cs
@@ -36,7 +36,7 @@ namespace InControl
 		static float currentTime;
 		static float lastUpdateTime;
 
-		static ulong currentTick;
+		public static ulong currentTick;
 
 
 		public static void Setup()


### PR DESCRIPTION
I need access to this to determine which type of input was last used (keyboard, mouse or joystick). Settled for this value, but it's just a suggestion. Alternatively I'd suggest just using plain Time.realtimeSinceStartup for lastUpdateTime and making that public. Might be even easier to use and find for people in need.
