### PR TITLE
Speedlink Strike for mac. D-pad fix.

### DIFF
--- a/Assets/InControl/Source/Unity/DeviceProfiles/SpeedlinkStrikeMacProfile.cs
+++ b/Assets/InControl/Source/Unity/DeviceProfiles/SpeedlinkStrikeMacProfile.cs
@@ -10,7 +10,7 @@ namespace InControl
 		public SpeedlinkStrikeMacProfile()
 		{
 			Name = "Speedlink Strike Controller";
-			Meta = "Speedlink Strike Controller on Mac";
+			Meta = "Speedlink Strike Controller on Mac (Analog mode)";
 
 			SupportedPlatforms = new[] {
 				"OS X"


### PR DESCRIPTION
Swapped in correct axes for Dpad (in analog mode). Will be a while before I can check the win profile, will send a pull request when i can. 
