### PR TITLE
Update PlayStation4WinProfile.cs

### DIFF
--- a/Assets/InControl/Source/Unity/DeviceProfiles/PlayStation4WinProfile.cs
+++ b/Assets/InControl/Source/Unity/DeviceProfiles/PlayStation4WinProfile.cs
@@ -53,12 +53,12 @@ namespace InControl
 				},
 				new InputControlMapping {
 					Handle = "Share",
-					Target = InputControlType.Share,
+					Target = InputControlType.Select,
 					Source = Button8
 				},
 				new InputControlMapping {
 					Handle = "Options",
-					Target = InputControlType.Select,
+					Target = InputControlType.Start,
 					Source = Button9
 				},
 				new InputControlMapping {


### PR DESCRIPTION
The 'Options' and 'Share' button map better to the standard 'Start' and 'Select' options on Windows as the current configuration doesn't make much sense (having no 'Start' and a 'Share' that's useless in Windows).
