### PR TITLE
Fixed build error on Windows Phone 8.

### DIFF
--- a/Assets/InControl/Source/InputManager.cs
+++ b/Assets/InControl/Source/InputManager.cs
@@ -371,7 +371,7 @@ namespace InControl
 
 		public static void HideDevicesWithProfile( Type type )
 		{
-			#if !UNITY_EDITOR && UNITY_WINRT
+			#if !UNITY_EDITOR && UNITY_METRO
 			if (type.GetTypeInfo().IsAssignableFrom( typeof( UnityInputDeviceProfile ).GetTypeInfo() ))
 			#else
 			if (type.IsSubclassOf( typeof(UnityInputDeviceProfile) ))


### PR DESCRIPTION
Windows Phone 8.0 does not know type.GetTypeInfo() but can use type.IsSubclassOf() like the standard .NET Framework or Mono.
