### PR TITLE
Allows use of two controllers with the same name by exposing the joystic...

### DIFF
--- a/Assets/InControl/Source/Device/InputDevice.cs
+++ b/Assets/InControl/Source/Device/InputDevice.cs
@@ -12,6 +12,7 @@ namespace InControl
 
 		public string Name { get; protected set; }
 		public string Meta { get; protected set; }
+		public virtual int JoystickId { get; protected set; }
 
 		public ulong LastChangeTick { get; protected set; }
 

--- a/Assets/InControl/Source/Unity/UnityInputDevice.cs
+++ b/Assets/InControl/Source/Unity/UnityInputDevice.cs
@@ -12,7 +12,7 @@ namespace InControl
 		public const int MaxButtons = 20;
 		public const int MaxAnalogs = 20;
 
-		internal int JoystickId { get; private set; }
+		public override int JoystickId { get; protected set; }
 		public UnityInputDeviceProfile Profile { get; protected set; }
 
 

--- a/Assets/InControl/Source/XInput/XInputDevice.cs
+++ b/Assets/InControl/Source/XInput/XInputDevice.cs
@@ -10,6 +10,12 @@ namespace InControl
 {
 	public class XInputDevice : InputDevice
 	{
+		public override int JoystickId
+		{
+			get { return DeviceIndex; }
+			protected set { DeviceIndex = value; }
+		}
+		
 		public int DeviceIndex { get; private set; }
 		GamePadState state;
 


### PR DESCRIPTION
I'm not sure if there is a reason this was not done. I made this change in the source for the game I am working on and everything works fine. Basically, this exposes the JoystickId from UnityInputDevice.cs inside InputDevice.cs so that it can be seen from inside your game, and you can use it to identify the controller instead of (or in addition to) the usual Name field. It also requires adding the field to XInputDevice, so I passed the field through to the DeviceIndex which seems to represent basically the same thing, therefore it would give a reasonable value for this as well.

I think this change is safe but it would be great if it could be reviewed. It will solve a whole lot of problems with having multiples of the same type of controller connected at the same time.