### PR TITLE
Update ExecutionerXProfile.cs

### DIFF
--- a/Assets/InControl/Source/Unity/DeviceProfiles/ExecutionerXProfile.cs
+++ b/Assets/InControl/Source/Unity/DeviceProfiles/ExecutionerXProfile.cs
@@ -18,6 +18,7 @@ namespace InControl
 			};
 
 			JoystickNames = new[] {
+				"Zeroplus PS Vibration Feedback Converter",
 				"Zeroplus PS Vibration Feedback Converter "
 			};
 


### PR DESCRIPTION
In OSX Yosemite the trailing space that used to be part of the device identifier (!) seems to be being stripped, so added both variations.